### PR TITLE
fix: Fix capture operations (#26)

### DIFF
--- a/src/VirtoCommerce.Datatrans.Core/Models/DatatransApiRoutes.cs
+++ b/src/VirtoCommerce.Datatrans.Core/Models/DatatransApiRoutes.cs
@@ -12,7 +12,7 @@ public class DatatransApiRoutes
     public string GetAuthorizeAuthenticatedPath(string transactionId) => $"/v1/transactions/{transactionId}/authorize";
 
     // POST
-    public string GetCapturePath(string transactionId) => $"/v1/transactions/{transactionId}/capture";
+    public string GetCapturePath(string transactionId) => $"/v1/transactions/{transactionId}/settle";
 
     // POST
     public string GetVoidPath(string transactionId) => $"/v1/transactions/{transactionId}/cancel";

--- a/src/VirtoCommerce.Datatrans.Core/Models/External/DatatransCaptureRequest.cs
+++ b/src/VirtoCommerce.Datatrans.Core/Models/External/DatatransCaptureRequest.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace VirtoCommerce.Datatrans.Core.Models.External;
 
 public class DatatransCaptureRequest
@@ -5,4 +7,11 @@ public class DatatransCaptureRequest
     public long Amount { get; set; }
     public string Currency { get; set; }
     public string Refno { get; set; }
+
+    /// <summary>
+    /// Airline data. When this is a string containing JSON, it is serialized as a JSON object/array in the request body.
+    /// https://api-reference.datatrans.ch/#tag/v1transactions/operation/settle
+    /// </summary>
+    [JsonConverter(typeof(RawJsonConverter))]
+    public object AirlineData { get; set; }
 }

--- a/src/VirtoCommerce.Datatrans.Core/Models/External/RawJsonConverter.cs
+++ b/src/VirtoCommerce.Datatrans.Core/Models/External/RawJsonConverter.cs
@@ -1,0 +1,38 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace VirtoCommerce.Datatrans.Core.Models.External;
+
+/// <summary>
+/// Serializes string values as raw JSON (parsed and embedded) instead of as a JSON string.
+/// Used for properties that may receive a JSON string but must be sent as an object/array in the payload.
+/// </summary>
+public class RawJsonConverter : JsonConverter
+{
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        if (value is string s && !string.IsNullOrEmpty(s))
+        {
+            var token = JToken.Parse(s);
+            token.WriteTo(writer);
+        }
+        else if (value != null)
+        {
+            var token = JToken.FromObject(value, serializer);
+            token.WriteTo(writer);
+        }
+        else
+        {
+            writer.WriteNull();
+        }
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        var token = JToken.Load(reader);
+        return token.Type == JTokenType.Object || token.Type == JTokenType.Array ? token : token.ToString();
+    }
+
+    public override bool CanConvert(Type objectType) => objectType == typeof(object);
+}

--- a/src/VirtoCommerce.Datatrans.Core/VirtoCommerce.Datatrans.Core.csproj
+++ b/src/VirtoCommerce.Datatrans.Core/VirtoCommerce.Datatrans.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.810.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.821.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.859.0" />

--- a/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
+++ b/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.Datatrans.Core;
 using VirtoCommerce.Datatrans.Core.Models.External;
@@ -161,6 +162,8 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
         var payment = (PaymentIn)context.Payment;
         var transactionId = GetTransactionId(context);
 
+        var airlineData = context.Parameters?.Get("airlineData");
+
         var alreadyCaptured = payment.Captures.Sum(x => x.Amount);
         var total = payment.Sum;
 
@@ -184,6 +187,7 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
             Amount = amountMinor,
             Currency = payment.Currency,
             Refno = transaction.Refno,
+            AirlineData = airlineData
         };
 
         var response = await datatransClient.CaptureAsync(transactionId, captureRequest);
@@ -195,6 +199,16 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
             transaction = await datatransClient.GetTransactionAsync(transactionId);
             payment.PaymentStatus = ConvertStatus(transaction.Status);
             payment.CapturedDate ??= DateTime.UtcNow;
+
+            payment.Captures ??= new List<Capture>();
+            payment.Captures.Add(new Capture
+            {
+                TransactionId = transaction.TransactionId,
+                Amount = payment.Sum,
+                Currency = payment.Currency,
+                CreatedDate = DateTime.UtcNow,
+                OuterId = transaction.TransactionId,
+            });
         }
         else
         {
@@ -397,14 +411,17 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
 
         payment.CapturedDate ??= DateTime.UtcNow;
         payment.Captures ??= new List<Capture>();
-        payment.Captures.Add(new Capture
+        if (newStatus != PaymentStatus.Authorized)
         {
-            TransactionId = transaction.TransactionId,
-            Amount = payment.Sum,
-            Currency = payment.Currency,
-            CreatedDate = DateTime.UtcNow,
-            OuterId = transaction.TransactionId,
-        });
+            payment.Captures.Add(new Capture
+            {
+                TransactionId = transaction.TransactionId,
+                Amount = payment.Sum,
+                Currency = payment.Currency,
+                CreatedDate = DateTime.UtcNow,
+                OuterId = transaction.TransactionId,
+            });
+        }
 
         var note = $"Transaction ID: {transaction.TransactionId}";
         if (!string.IsNullOrEmpty(transaction.MerchantId))

--- a/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
+++ b/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
@@ -204,7 +204,7 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
             payment.Captures.Add(new Capture
             {
                 TransactionId = transaction.TransactionId,
-                Amount = payment.Sum,
+                Amount = amountToCapture,
                 Currency = payment.Currency,
                 CreatedDate = DateTime.UtcNow,
                 OuterId = transaction.TransactionId,


### PR DESCRIPTION
## Description
fix: Fixed capture URL - an incorrect one was used.
fix: Fixed Payment.Capture creation. Capture shouldn't be created if a payment is only authorized, not settled
fix: Added support for airlineData payload


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4782
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Datatrans_3.802.0-pr-27-bd34.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Datatrans capture/settlement endpoint and alters when/what capture records are created, which can affect payment state transitions and reconciliation.
> 
> **Overview**
> Fixes Datatrans capture calls to use the correct `POST /v1/transactions/{id}/settle` endpoint instead of `/capture`.
> 
> Extends capture requests to optionally include `airlineData`, adding a `RawJsonConverter` so JSON strings are embedded as raw objects/arrays in the payload.
> 
> Adjusts payment capture bookkeeping: capture operations now append a `Capture` record on successful settle, and post-processing no longer creates a `Capture` entry when the transaction is only `Authorized` (not settled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd346bf597b4045d37375b9f68a1456b37e9530b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->