### PR TITLE
VCST-4893: Add support for payment localization

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet build:*)",
+      "Bash(grep -n 'globals\\\\.storeId\\\\|globals\\\\.cultureName\\\\|globals\\\\.$config\\\\|globals = {' C:/Projects/git/VirtoCommerce/vc-frontend/client-app/core/globals.ts)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(dotnet build:*)",
-      "Bash(grep -n 'globals\\\\.storeId\\\\|globals\\\\.cultureName\\\\|globals\\\\.$config\\\\|globals = {' C:/Projects/git/VirtoCommerce/vc-frontend/client-app/core/globals.ts)"
-    ]
-  }
-}

--- a/README.md
+++ b/README.md
@@ -118,11 +118,17 @@ On every call to `ProcessPaymentAsync` in Lightbox mode, the module picks the la
 
 Virto Commerce uses .NET culture names (e.g. `en-US`, `de-CH`). The module takes the 2-letter primary subtag and matches it against Datatrans's supported set:
 
-```
-en, de, fr, it, es, el, no, da, pl, pt,
-fi, sv, nl, cs, ja, zh, ru, hu, hr, sr,
-sl, tr, ar, ko
-```
+| Code | Language |   | Code | Language |
+|------|----------|---|------|----------|
+| `en` | English  |   | `da` | Danish   |
+| `de` | German   |   | `pl` | Polish   |
+| `fr` | French   |   | `pt` | Portuguese |
+| `it` | Italian  |   | `ru` | Russian  |
+| `es` | Spanish  |   | `ja` | Japanese |
+| `el` | Greek    |   |      |          |
+| `no` | Norwegian|   |      |          |
+
+If you need an additional language, Datatrans can add it on request — [contact Datatrans support](https://docs.datatrans.ch/docs/redirect-lightbox#language-support).
 
 Examples: `en-US` → `en`, `de-CH` → `de`, `fr-FR` → `fr`, `en-GB` → `en`. Unsupported cultures resolve to `null` → Datatrans default.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Both modes support 3-D Secure authentication, authorize/capture, void, and refun
 - Full payment lifecycle: authorize, capture, void, refund
 - Sandbox and production environments
 - 3-D Secure support
-- UI localization — error messages, labels, and SecureFields strings are rendered in the shopper's current culture via the Datatrans `language` parameter
+- UI localization for Lightbox — the popup is rendered in the shopper's current culture via the Datatrans `language` parameter
 
 ## Installation
 
@@ -102,11 +102,13 @@ For more details, see the [Datatrans Lightbox documentation](https://docs.datatr
 
 ## Localization
 
-Both Lightbox and Secure Fields localize their UI via the Datatrans `language` request parameter. See the [Datatrans language-support docs](https://docs.datatrans.ch/docs/redirect-lightbox#language-support) for the full list of supported codes.
+**Lightbox** localizes its UI via the Datatrans `language` request parameter on `POST /v1/transactions`. See the [Datatrans language-support docs](https://docs.datatrans.ch/docs/redirect-lightbox#language-support) for the full list of supported codes.
 
-### How the language is resolved
+**Secure Fields** does **not** accept `language` on `POST /v1/transactions/secureFields` — sending it yields `Unrecognized property: language`. Secure Fields localizes its inline iframes via the client-side JS library (`SecureFields.init({ language: "de", … })`); to switch the Secure Fields UI language, pass the culture through your frontend wrapper when it constructs the `SecureFields` instance.
 
-On every call to `ProcessPaymentAsync`, the module picks the language in this order:
+### How the Lightbox language is resolved
+
+On every call to `ProcessPaymentAsync` in Lightbox mode, the module picks the language in this order:
 
 1. **`ProcessPaymentRequest.CultureName`** — the shopper's culture, carried on `PaymentRequestBase` by the X-API payment mutations (`initializeCartPayment`, `initializePayment`, `authorizePayment`). The storefront passes this from `useLanguages().currentLanguage.value.cultureName`.
 2. **`Store.DefaultLanguage`** — fallback when the mutation caller did not pass `cultureName`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Both modes support 3-D Secure authentication, authorize/capture, void, and refun
 - Full payment lifecycle: authorize, capture, void, refund
 - Sandbox and production environments
 - 3-D Secure support
+- UI localization — error messages, labels, and SecureFields strings are rendered in the shopper's current culture via the Datatrans `language` parameter
 
 ## Installation
 
@@ -99,6 +100,59 @@ In Lightbox mode, the customer clicks a "Pay" button and a Datatrans popup overl
 
 For more details, see the [Datatrans Lightbox documentation](https://docs.datatrans.ch/docs/redirect-lightbox).
 
+## Localization
+
+Both Lightbox and Secure Fields localize their UI via the Datatrans `language` request parameter. See the [Datatrans language-support docs](https://docs.datatrans.ch/docs/redirect-lightbox#language-support) for the full list of supported codes.
+
+### How the language is resolved
+
+On every call to `ProcessPaymentAsync`, the module picks the language in this order:
+
+1. **`ProcessPaymentRequest.CultureName`** — the shopper's culture, carried on `PaymentRequestBase` by the X-API payment mutations (`initializeCartPayment`, `initializePayment`, `authorizePayment`). The storefront passes this from `useLanguages().currentLanguage.value.cultureName`.
+2. **`Store.DefaultLanguage`** — fallback when the mutation caller did not pass `cultureName`.
+3. **Omitted** — if the resolved culture is empty or maps to an unsupported code, the `language` field is stripped from the Datatrans payload and the gateway renders in its own default (English). No wire change occurs for deployments that never pass a culture.
+
+### Culture-to-Datatrans mapping
+
+Virto Commerce uses .NET culture names (e.g. `en-US`, `de-CH`). The module takes the 2-letter primary subtag and matches it against Datatrans's supported set:
+
+```
+en, de, fr, it, es, el, no, da, pl, pt,
+fi, sv, nl, cs, ja, zh, ru, hu, hr, sr,
+sl, tr, ar, ko
+```
+
+Examples: `en-US` → `en`, `de-CH` → `de`, `fr-FR` → `fr`, `en-GB` → `en`. Unsupported cultures resolve to `null` → Datatrans default.
+
+### Overriding the mapping
+
+`DatatransPaymentMethod.CreateInitRequest` is `protected virtual` and sets `result.Language` from `request.CultureName`. Override the method in a derived payment method if you need different culture logic (e.g. force a specific language, support a non-standard locale, or fall back to a configured default).
+
+### Calling the mutations with a culture
+
+```graphql
+mutation InitializeCartPayment($command: InputInitializeCartPaymentType!) {
+  initializeCartPayment(command: $command) {
+    isSuccess
+    paymentActionType
+    publicParameters { key value }
+  }
+}
+```
+
+```json
+{
+  "command": {
+    "cartId": "…",
+    "paymentId": "…",
+    "storeId": "…",
+    "cultureName": "de-CH"
+  }
+}
+```
+
+`storeId` is optional; when provided, X-API verifies it matches the cart/order store and throws otherwise. `cultureName` is optional and falls back to the store's default language.
+
 ## Frontend Integration
 
 The module includes Vue.js components for the Virto Commerce Frontend application:
@@ -113,6 +167,7 @@ The frontend automatically detects the payment mode from the backend configurati
 * [Datatrans Introduction](https://docs.datatrans.ch/docs/introduction)
 * [Lightbox mode](https://docs.datatrans.ch/docs/redirect-lightbox)
 * [Secure Fields mode](https://docs.datatrans.ch/docs/redirect-lightbox)
+* [Language support](https://docs.datatrans.ch/docs/redirect-lightbox#language-support)
 
 ## License
 

--- a/src/VirtoCommerce.Datatrans.Core/Models/External/DatatransInitRequest.cs
+++ b/src/VirtoCommerce.Datatrans.Core/Models/External/DatatransInitRequest.cs
@@ -5,6 +5,12 @@ public class DatatransInitRequest
     public long Amount { get; set; }
     public string Currency { get; set; }
 
+    /// <summary>
+    /// 2-letter language code for UI localization (e.g. "en", "de", "fr").
+    /// See https://docs.datatrans.ch/docs/redirect-lightbox#language-support.
+    /// </summary>
+    public string Language { get; set; }
+
     // Secure Fields-specific fields
     public string ReturnUrl { get; set; }
     public string ReturnMethod { get; set; }

--- a/src/VirtoCommerce.Datatrans.Core/VirtoCommerce.Datatrans.Core.csproj
+++ b/src/VirtoCommerce.Datatrans.Core/VirtoCommerce.Datatrans.Core.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />

--- a/src/VirtoCommerce.Datatrans.Core/VirtoCommerce.Datatrans.Core.csproj
+++ b/src/VirtoCommerce.Datatrans.Core/VirtoCommerce.Datatrans.Core.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />

--- a/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
+++ b/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
@@ -284,7 +284,6 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
 
         result.Amount = await ToMinorUnits(currency, payment.Sum);
         result.Currency = currency;
-        result.Language = MapToDatatransLanguage(request.CultureName ?? store.DefaultLanguage);
 
         var returnUrl = Settings.GetValue<string>(ModuleConstants.Settings.General.ReturnUrl)
             .Replace("{orderId}", order.Id)
@@ -294,6 +293,12 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
 
         if (IsLightboxMode())
         {
+            // Lightbox accepts a `language` parameter; Secure Fields does not and returns
+            // "Unrecognized property: language" when present.
+            // Use EmptyToNull() so an empty CultureName falls back to the store default
+            // (matches the pattern used for Currency above).
+            result.Language = MapToDatatransLanguage(request.CultureName.EmptyToNull() ?? store.DefaultLanguage);
+
             // Lightbox uses redirect object instead of returnUrl/returnMethod
             result.Refno = order.Number ?? order.Id;
 
@@ -376,6 +381,15 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
         return mode.EqualsIgnoreCase("Lightbox");
     }
 
+    // Datatrans-supported UI languages for Lightbox; any other value causes the API to return
+    // HTTP 400. See https://docs.datatrans.ch/docs/redirect-lightbox#language-support
+    private static readonly HashSet<string> _datatransLanguages = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "en", "de", "fr", "it", "es", "el", "no", "da", "pl", "pt",
+        "fi", "sv", "nl", "cs", "ja", "zh", "ru", "hu", "hr", "sr",
+        "sl", "tr", "ar", "ko",
+    };
+
     private static string MapToDatatransLanguage(string cultureName)
     {
         if (string.IsNullOrEmpty(cultureName))
@@ -383,7 +397,9 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
             return null;
         }
 
-        return cultureName.Split('-')[0].ToLowerInvariant();
+        var code = cultureName.Split('-')[0].ToLowerInvariant();
+
+        return _datatransLanguages.Contains(code) ? code : null;
     }
 
     private static string GetTransactionId(PaymentRequestBase context)

--- a/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
+++ b/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
@@ -284,6 +284,7 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
 
         result.Amount = await ToMinorUnits(currency, payment.Sum);
         result.Currency = currency;
+        result.Language = MapToDatatransLanguage(request.CultureName ?? store.DefaultLanguage);
 
         var returnUrl = Settings.GetValue<string>(ModuleConstants.Settings.General.ReturnUrl)
             .Replace("{orderId}", order.Id)
@@ -373,6 +374,16 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
     {
         var mode = Settings.GetValue<string>(ModuleConstants.Settings.General.PaymentMode);
         return mode.EqualsIgnoreCase("Lightbox");
+    }
+
+    private static string MapToDatatransLanguage(string cultureName)
+    {
+        if (string.IsNullOrEmpty(cultureName))
+        {
+            return null;
+        }
+
+        return cultureName.Split('-')[0].ToLowerInvariant();
     }
 
     private static string GetTransactionId(PaymentRequestBase context)

--- a/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
+++ b/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
@@ -390,6 +390,14 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
         "en", "de", "fr", "it", "es", "el", "no", "da", "pl", "pt", "ru", "ja",
     };
 
+    // .NET culture subtags that map to a different Datatrans language code.
+    // Norwegian: .NET uses "nb" (Bokmål) and "nn" (Nynorsk); Datatrans expects "no".
+    private static readonly Dictionary<string, string> _languageAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["nb"] = "no",
+        ["nn"] = "no",
+    };
+
     private static string MapToDatatransLanguage(string cultureName)
     {
         if (string.IsNullOrEmpty(cultureName))
@@ -398,6 +406,11 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
         }
 
         var code = cultureName.Split('-')[0].ToLowerInvariant();
+
+        if (_languageAliases.TryGetValue(code, out var alias))
+        {
+            code = alias;
+        }
 
         return _datatransLanguages.Contains(code) ? code : null;
     }

--- a/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
+++ b/src/VirtoCommerce.Datatrans.Data/Providers/DatatransPaymentMethod.cs
@@ -381,13 +381,13 @@ public class DatatransPaymentMethod(IDatatransClient datatransClient, ICurrencyS
         return mode.EqualsIgnoreCase("Lightbox");
     }
 
-    // Datatrans-supported UI languages for Lightbox; any other value causes the API to return
-    // HTTP 400. See https://docs.datatrans.ch/docs/redirect-lightbox#language-support
+    // Datatrans-supported UI languages for Redirect and Lightbox; any other value causes the
+    // API to return HTTP 400. See https://docs.datatrans.ch/docs/redirect-lightbox#language-support
+    // Supported: English, German, French, Italian, Spanish, Greek, Norwegian, Danish,
+    //            Polish, Portuguese, Russian, Japanese.
     private static readonly HashSet<string> _datatransLanguages = new(StringComparer.OrdinalIgnoreCase)
     {
-        "en", "de", "fr", "it", "es", "el", "no", "da", "pl", "pt",
-        "fi", "sv", "nl", "cs", "ja", "zh", "ru", "hu", "hr", "sr",
-        "sl", "tr", "ar", "ko",
+        "en", "de", "fr", "it", "es", "el", "no", "da", "pl", "pt", "ru", "ja",
     };
 
     private static string MapToDatatransLanguage(string cultureName)

--- a/src/VirtoCommerce.Datatrans.Web/module.manifest
+++ b/src/VirtoCommerce.Datatrans.Web/module.manifest
@@ -6,13 +6,13 @@
 
   <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Payment" version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
+    <dependency id="VirtoCommerce.Payment" version="3.1002.0" />
     <dependency id="VirtoCommerce.Store" version="3.1000.0" />
     <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
   </dependencies>
 
-  <title>VirtoCommerce Datatrans</title>
-  <description>VirtoCommerce Datatrans</description>
+  <title>Datatrans Payment</title>
+  <description>Datatrans payment module provides integration with Datatrans payment gateway for Virto Commerce.</description>
 
   <authors>
     <author>Basil Kotov</author>

--- a/src/VirtoCommerce.Datatrans.Web/module.manifest
+++ b/src/VirtoCommerce.Datatrans.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
     <dependency id="VirtoCommerce.Store" version="3.1000.0" />
     <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
   </dependencies>


### PR DESCRIPTION
## Description
feat: Adds the support for payment localization

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4893
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Datatrans_3.1001.0-pr-32-9dfb.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies Datatrans transaction initialization payload in Lightbox mode and adds culture-to-language mapping; mistakes could cause gateway init failures (HTTP 400) or unexpected fallback behavior. Also bumps the `VirtoCommerce.Payment` dependency, which may introduce subtle runtime compatibility changes.
> 
> **Overview**
> Adds **Lightbox UI localization** by sending Datatrans `language` during transaction initialization, resolved from `ProcessPaymentRequest.CultureName` with fallback to `Store.DefaultLanguage` and omitted when unsupported.
> 
> Implements culture-to-Datatrans language mapping (including Norwegian `nb/nn` → `no`) to avoid invalid codes, extends `DatatransInitRequest` with `Language`, updates module/package dependencies to `VirtoCommerce.Payment`/`VirtoCommerce.PaymentModule.Core` `3.1002.0`, and refreshes `README`/manifest metadata to document the new localization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dfb9c65b36168d4d09af90ee8305cbccfaf1599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->